### PR TITLE
chore: add Citroen VR7 to WMIs dictionary

### DIFF
--- a/vininfo/dicts/wmi.py
+++ b/vininfo/dicts/wmi.py
@@ -544,6 +544,7 @@ WMI = {
     'VNE': 'Irisbus',
     'VNK': 'Toyota',
     'VNV': Renault(),
+    'VR7': 'Citroën',
     'VS1': 'Iveco',
     'VS3': 'Peugeot',
     'VS5': Renault(),


### PR DESCRIPTION
Just adding a Citroen WMI that is missing in current dictionary in an attempt to fix a different issue.
See https://github.com/zeld/psa-update/issues/7 if you care.