### PR TITLE
Assembler logic (Issue #28)

### DIFF
--- a/tests/test_bajaj.py
+++ b/tests/test_bajaj.py
@@ -1,0 +1,280 @@
+from vininfo import Vin
+
+base_expected = {
+    'brand': 'Bajaj (Bajaj)',
+    'body_code': '',
+    'body_name': 'Motorcycle',
+}
+
+brazil_base_expected = {
+    'wmi': '92T',
+    'manufacturer': 'Bajaj',
+    'region_code': '9',
+    'region': 'South America',
+    'country_code': '92',
+    'country': 'Brazil',
+    'assembler': 'Bajaj (Bajaj)',
+    'plant_code': 'M',
+    'plant_name': 'Manaus',
+    **base_expected
+}
+
+dafra_base_expected = {
+    'wmi': '95V',
+    'manufacturer': 'Dafra',
+    'region_code': '9',
+    'region': 'South America',
+    'country_code': '95',
+    'country': 'Brazil',
+    'assembler': 'Dafra (Dafra)',
+    'plant_code': 'M',
+    'plant_name': 'Manaus',
+    **base_expected
+}
+
+india_base_expected = {
+    'wmi': 'MD2',
+    'manufacturer': 'Bajaj',
+    'region_code': 'M',
+    'region': 'Asia',
+    'country_code': 'MD',
+    'country': 'India',
+    'assembler': 'Bajaj (Bajaj)',
+    'plant_code': 'C',
+    'plant_name': 'Chakan',
+    **base_expected
+}
+
+
+def data_provider():
+    return [
+        {
+            'vin': '95V2A1E5PPM099209',
+            'expected': {
+                'vds': '2A1E5P',
+                'vis': 'PM099209',
+                'serial_code': '099209',
+                'squish_vin': '95V2A1E5PM',
+                'years_code': 'P',
+                'years': [2023, 1993],
+                'model_code': '2A1',
+                'model_name': 'Dominar 160',
+                **dafra_base_expected
+            }
+        },
+        {
+            'vin': '95V2B1K5NPM099112',
+            'expected': {
+                'vds': '2B1K5N',
+                'vis': 'PM099112',
+                'serial_code': '099112',
+                'squish_vin': '95V2B1K5PM',
+                'years_code': 'P',
+                'years': [2023, 1993],
+                'model_code': '2B1',
+                'model_name': 'Dominar 200',
+                **dafra_base_expected
+            }
+        },
+        {
+            'vin': '95V3B1J5NPM099022',
+            'expected': {
+                'vds': '3B1J5N',
+                'vis': 'PM099022',
+                'serial_code': '099022',
+                'squish_vin': '95V3B1J5PM',
+                'years_code': 'P',
+                'years': [2023, 1993],
+                'model_code': '3B1',
+                'model_name': 'Dominar 400',
+                **dafra_base_expected
+            }
+        },
+        {
+            'vin': '92TA92DZXRMC09006',
+            'expected': {
+                'vds': 'A92DZX',
+                'vis': 'RMC09006',
+                'serial_code': 'C09006',
+                'squish_vin': '92TA92DZRM',
+                'years_code': 'R',
+                'years': [2024, 1994],
+                'model_code': 'A92',
+                'model_name': 'Dominar 160',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': '92TA92DX4TML92419',
+            'expected': {
+                'vds': 'A92DX4',
+                'vis': 'TML92419',
+                'serial_code': 'L92419',
+                'squish_vin': '92TA92DXTM',
+                'years_code': 'T',
+                'years': [2026, 1996],
+                'model_code': 'A92',
+                'model_name': 'Dominar NS160',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': '92TA36FZ8RMC90909',
+            'expected': {
+                'vds': 'A36FZ8',
+                'vis': 'RMC90909',
+                'serial_code': 'C90909',
+                'squish_vin': '92TA36FZRM',
+                'years_code': 'R',
+                'years': [2024, 1994],
+                'model_code': 'A36',
+                'model_name': 'Dominar 200',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': '92TA36FX9TML92914',
+            'expected': {
+                'vds': 'A36FX9',
+                'vis': 'TML92914',
+                'serial_code': 'L92914',
+                'squish_vin': '92TA36FXTM',
+                'years_code': 'T',
+                'years': [2026, 1996],
+                'model_code': 'A36',
+                'model_name': 'Dominar NS200',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': '92TB65GZ1RMD90922',
+            'expected': {
+                'vds': 'B65GZ1',
+                'vis': 'RMD90922',
+                'serial_code': 'D90922',
+                'squish_vin': '92TB65GZRM',
+                'years_code': 'R',
+                'years': [2024, 1994],
+                'model_code': 'B65',
+                'model_name': 'Dominar 250',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': '92TA67MZ1RMC90909',
+            'expected': {
+                'vds': 'A67MZ1',
+                'vis': 'RMC90909',
+                'serial_code': 'C90909',
+                'squish_vin': '92TA67MZRM',
+                'years_code': 'R',
+                'years': [2024, 1994],
+                'model_code': 'A67',
+                'model_name': 'Dominar 400',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': '92TC41CX1TMB90948',
+            'expected': {
+                'vds': 'C41CX1',
+                'vis': 'TMB90948',
+                'serial_code': 'B90948',
+                'squish_vin': '92TC41CXTM',
+                'years_code': 'T',
+                'years': [2026, 1996],
+                'model_code': 'C41',
+                'model_name': 'Pulsar N150',
+                **brazil_base_expected
+            }
+        },
+        {
+            'vin': 'MD2A67MXXRCK99693',
+            'expected': {
+                'vds': 'A67MXX',
+                'vis': 'RCK99693',
+                'serial_code': 'K99693',
+                'squish_vin': 'MD2A67MXRC',
+                'years_code': 'R',
+                'years': [2024, 1994],
+                'model_code': 'A67',
+                'model_name': 'Dominar 400',
+                **india_base_expected
+            }
+        },
+        {
+            'vin': 'MD2B65GX9PCF91987',
+            'expected': {
+                'vds': 'B65GX9',
+                'vis': 'PCF91987',
+                'serial_code': 'F91987',
+                'squish_vin': 'MD2B65GXPC',
+                'years_code': 'P',
+                'years': [2023, 1993],
+                'model_code': 'B65',
+                'model_name': 'Dominar 250',
+                **india_base_expected
+            }
+        },
+        {
+            'vin': 'MD2B97FX1PCB96793',
+            'expected': {
+                'vds': 'B97FX1',
+                'vis': 'PCB96793',
+                'serial_code': 'B96793',
+                'squish_vin': 'MD2B97FXPC',
+                'years_code': 'P',
+                'years': [2023, 1993],
+                'model_code': 'B97',
+                'model_name': 'Pulsar N250',
+                **india_base_expected
+            }
+        },
+        {
+            'vin': 'MD2B54DX5PCB94941',
+            'expected': {
+                'vds': 'B54DX5',
+                'vis': 'PCB94941',
+                'serial_code': 'B94941',
+                'squish_vin': 'MD2B54DXPC',
+                'years_code': 'P',
+                'years': [2023, 1993],
+                'model_code': 'B54',
+                'model_name': 'Pulsar N160',
+                **india_base_expected
+            }
+        },
+    ]
+
+
+def test_bajaj():
+    for data in data_provider():
+        vin = data.get('vin')
+        expected = data.get('expected')
+        vin = Vin(vin)
+
+        assert '%s' % vin
+        assert vin.wmi == expected.get('wmi'), f'For {vin}'
+        assert vin.manufacturer == expected.get('manufacturer'), f'For {vin}'
+        assert '%s' % vin.assembler == expected.get('assembler'), f'For {vin}'
+        assert vin.vds == expected.get('vds'), f'For {vin}'
+        assert vin.vis == expected.get('vis'), f'For {vin}'
+        assert vin.years_code == expected.get('years_code'), f'For {vin}'
+        assert vin.years == expected.get('years'), f'For {vin}'
+        assert vin.region_code == expected.get('region_code'), f'For {vin}'
+        assert vin.region == expected.get('region'), f'For {vin}'
+        assert vin.country_code == expected.get('country_code'), f'For {vin}'
+        assert vin.country == expected.get('country'), f'For {vin}'
+        assert '%s' % vin.brand == expected.get('brand'), f'For {vin}'
+        assert vin.squish_vin == expected.get('squish_vin'), f'For {vin}'
+
+        details = vin.details
+        assert details.model.code == expected.get('model_code'), f'For {vin}'
+        assert details.model.name == expected.get('model_name'), f'For {vin}'
+        assert details.body.code == expected.get('body_code'), f'For {vin}'
+        assert details.body.name == expected.get('body_name'), f'For {vin}'
+        assert not details.engine, f'For {vin}'
+        assert not details.transmission, f'For {vin}'
+        assert details.plant.code == expected.get('plant_code'), f'For {vin}'
+        assert details.plant.name == expected.get('plant_name'), f'For {vin}'
+        assert details.serial.code == expected.get('serial_code'), f'For {vin}'

--- a/tests/test_dafra.py
+++ b/tests/test_dafra.py
@@ -1,0 +1,109 @@
+from vininfo import Vin
+
+base_expected = {
+    'wmi': '95V',
+    'region_code': '9',
+    'region': 'South America',
+    'country_code': '95',
+    'country': 'Brazil',
+    'assembler': 'Dafra (Dafra)',
+    'manufacturer': 'Dafra',
+    'brand': 'Dafra (Dafra)',
+    'body_code': '',
+    'body_name': 'Motorcycle',
+    'plant_code': 'M',
+    'plant_name': 'Manaus',
+}
+
+def data_provider():
+    return [
+        {
+            'vin': '95VCB1K589M017683',
+            'expected': {
+                'vds': 'CB1K58',
+                'vis': '9M017683',
+                'serial_code': '017683',
+                'squish_vin': '95VCB1K59M',
+                'years_code': '9',
+                'years': [2009],
+                'model_code': 'CB',
+                'model_name': 'Kansas 150',
+                **base_expected
+            }
+        },
+        {
+            'vin': '95VCB1K589M022466',
+            'expected': {
+                'vds': 'CB1K58',
+                'vis': '9M022466',
+                'serial_code': '022466',
+                'squish_vin': '95VCB1K59M',
+                'years_code': '9',
+                'years': [2009],
+                'model_code': 'CB',
+                'model_name': 'Kansas 150',
+                **base_expected
+            }
+        },
+        {
+            'vin': '95VCA1C899M010049',
+            'expected': {
+                'vds': 'CA1C89',
+                'vis': '9M010049',
+                'serial_code': '010049',
+                'squish_vin': '95VCA1C89M',
+                'years_code': '9',
+                'years': [2009],
+                'model_code': 'CA',
+                'model_name': 'Speed 150',
+                **base_expected
+            }
+        },
+        {
+            'vin': '95VCA4A8BBM001656',
+            'expected': {
+                'vds': 'CA4A8B',
+                'vis': 'BM001656',
+                'serial_code': '001656',
+                'squish_vin': '95VCA4A8BM',
+                'years_code': 'B',
+                'years': [2011, 1981],
+                'model_code': 'CA',
+                'model_name': 'Speed 150',
+                **base_expected
+            }
+        },
+    ]
+
+
+def test_dafra():
+    for data in data_provider():
+        vin = data.get('vin')
+        expected = data.get('expected')
+        vin = Vin(vin)
+
+        assert '%s' % vin
+        assert vin.wmi == expected.get('wmi'), f'For {vin}'
+        assert vin.manufacturer == expected.get('manufacturer'), f'For {vin}'
+        assert '%s' % vin.assembler == expected.get('assembler'), f'For {vin}'
+        assert vin.vds == expected.get('vds'), f'For {vin}'
+        assert vin.vis == expected.get('vis'), f'For {vin}'
+        assert vin.years_code == expected.get('years_code'), f'For {vin}'
+        assert vin.years == expected.get('years'), f'For {vin}'
+        assert vin.region_code == expected.get('region_code'), f'For {vin}'
+        assert vin.region == expected.get('region'), f'For {vin}'
+        assert vin.country_code == expected.get('country_code'), f'For {vin}'
+        assert vin.country == expected.get('country'), f'For {vin}'
+        assert '%s' % vin.brand == expected.get('brand'), f'For {vin}'
+        assert vin.squish_vin == expected.get('squish_vin'), f'For {vin}'
+
+        details = vin.details
+        assert details.model.code == expected.get('model_code'), f'For {vin}'
+        assert details.model.name == expected.get('model_name'), f'For {vin}'
+        assert details.body.code == expected.get('body_code'), f'For {vin}'
+        assert details.body.name == expected.get('body_name'), f'For {vin}'
+        assert not details.engine, f'For {vin}'
+        assert not details.transmission, f'For {vin}'
+        assert details.plant.code == expected.get('plant_code'), f'For {vin}'
+        assert details.plant.name == expected.get('plant_name'), f'For {vin}'
+        assert details.serial.code == expected.get('serial_code'), f'For {vin}'

--- a/tests/test_lada.py
+++ b/tests/test_lada.py
@@ -12,6 +12,7 @@ def test_lada():
     assert vin.manufacturer == 'AvtoVAZ'
     assert vin.vds == 'GFK330'
     assert vin.vis == 'JY144213'
+    assert vin.years_code == 'J'
     assert vin.years == [2018, 1988]
     assert vin.region_code == 'X'
     assert vin.region == 'Europe'

--- a/tests/test_nissan.py
+++ b/tests/test_nissan.py
@@ -10,7 +10,8 @@ def test_nissan():
     assert vin.manufacturer == 'Nissan'
     assert vin.vds == 'NJ01CX'
     assert vin.vis == 'ST000001'
-    assert vin.years == [1995]
+    assert vin.years_code == 'S'
+    assert vin.years == [2025, 1995]
     assert vin.region_code == '5'
     assert vin.region == 'North America'
     assert vin.country_code == '5N'

--- a/tests/test_opel.py
+++ b/tests/test_opel.py
@@ -10,6 +10,7 @@ def test_opel():
     assert vin.manufacturer == 'Opel/Vauxhall'
     assert vin.vds == 'PC6DB3'
     assert vin.vis == 'CC123456'
+    assert vin.years_code == 'C'
     assert vin.years == [2012, 1982]
     assert vin.region_code == 'W'
     assert vin.region == 'Europe'

--- a/tests/test_renault.py
+++ b/tests/test_renault.py
@@ -10,6 +10,7 @@ def test_renault():
     assert vin.manufacturer == 'Renault'
     assert vin.vds == '4SRAP4'
     assert vin.vis == '51234567'
+    assert vin.years_code == '5'
     assert vin.years == [2005]
     assert vin.region_code == 'V'
     assert vin.region == 'Europe'

--- a/vininfo/assemblers.py
+++ b/vininfo/assemblers.py
@@ -1,0 +1,6 @@
+from .brands import Bajaj, Dafra
+from .common import Assembler
+
+
+class Dafra(Assembler):
+    brands = {Dafra(), Bajaj(), 'BMW'}

--- a/vininfo/brands.py
+++ b/vininfo/brands.py
@@ -20,3 +20,13 @@ class Opel(Brand):
 class Renault(Brand):
 
     extractor = RenaultDetails
+
+
+class Dafra(Brand):
+
+    extractor = DafraDetails
+
+
+class Bajaj(Brand):
+
+    extractor = BajajDetails

--- a/vininfo/common.py
+++ b/vininfo/common.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Dict, Any, Type, Set, TYPE_CHECKING, List
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: # pragma: nocover
     from .details._base import VinDetails  # noqa
 
 def constant_info(info):

--- a/vininfo/common.py
+++ b/vininfo/common.py
@@ -1,7 +1,30 @@
-from typing import Dict, Any, Type
+from datetime import datetime
+from typing import Dict, Any, Type, Set, TYPE_CHECKING, List
 
-if False:  # pragma: nocover
+if TYPE_CHECKING:
     from .details._base import VinDetails  # noqa
+
+def constant_info(info):
+    """Emulate details logic to always return the same information."""
+    return lambda details: type("", (), {"get": (lambda code: info)})
+
+def candidate_by_year_model_mapping(mapping: Dict[str, Dict[str, str]], years: List[int]):
+    candidate_mapping = {}
+    for model_year_range, candidates in mapping.items():
+        start_model_year, end_model_year = model_year_range.split('-')
+
+        if not start_model_year and not end_model_year:
+            candidate_mapping.update(candidates)
+            continue
+
+        start_model_year = int(start_model_year)
+        end_model_year = int(end_model_year) if end_model_year else max(datetime.now().year, start_model_year) + 1
+
+        filter_years = [year for year in years if start_model_year <= year <= end_model_year]
+        if filter_years:
+            candidate_mapping.update(candidates)
+
+    return candidate_mapping
 
 
 class Annotatable:
@@ -27,11 +50,12 @@ class Annotatable:
         return dict((title, value) for title, value in sorted(annotations.items(), key=lambda item: item[0]))
 
 
-class Brand:
 
+class Assembler:
+    """Assembler is a manufacturer that has a WMI and assemble vehicles for other brands using its own WMI."""
     __slots__ = ['manufacturer']
 
-    extractor: Type['VinDetails'] = None
+    brands: Set['Brand'] = None
 
     def __init__(self, manufacturer: str = None):
         self.manufacturer = manufacturer or self.title
@@ -42,6 +66,15 @@ class Brand:
 
     def __str__(self):
         return f'{self.title} ({self.manufacturer})'
+
+
+
+class Brand(Assembler):
+    extractor: Type['VinDetails'] = None
+
+    @property
+    def brands(self) -> Set['Brand']:
+        return {self}
 
 
 class UnsupportedBrand(Brand):

--- a/vininfo/details/__init__.py
+++ b/vininfo/details/__init__.py
@@ -1,4 +1,6 @@
 from .avtovaz import AvtoVazDetails
+from .bajaj import BajajDetails
+from .dafra import DafraDetails
 from .nissan import NissanDetails
 from .opel import OpelDetails
 from .renault import RenaultDetails

--- a/vininfo/details/_base.py
+++ b/vininfo/details/_base.py
@@ -1,8 +1,8 @@
-from typing import Optional, Type
+from typing import Optional, Type, TYPE_CHECKING
 
 from ..common import Annotatable
 
-if False:  # pragma: nocover
+if TYPE_CHECKING:  # pragma: nocover
     from ..toolbox import Vin  # noqa
 
 
@@ -33,11 +33,11 @@ class DetailWrapper:
         if callable(defs):
             defs = defs(details)
 
-        self._supported = bool(source)
-        """Flag indicating that this detail extraction is available."""
-
         self.code: str = code
         self.name: Optional[str] = defs.get(code)
+
+        self._supported = bool(source) or bool(self.name)
+        """Flag indicating that this detail extraction is available."""
 
     def __str__(self):
         return self.name or self.code

--- a/vininfo/details/bajaj.py
+++ b/vininfo/details/bajaj.py
@@ -1,0 +1,89 @@
+from ._base import VinDetails, Detail
+from ..common import candidate_by_year_model_mapping, constant_info
+from ..dicts.bodies import BODY_MOTORCYCLE
+
+
+def get_wmi(details: VinDetails):
+    # noinspection PyProtectedMember
+    return details._vin.wmi
+
+
+def get_years(details: VinDetails):
+    # noinspection PyProtectedMember
+    return details._vin.years
+
+
+def get_model(details: VinDetails):
+    """It looks like Bajaj Brazil is using the same VDS mapping that Bajaj India, or a pretty close one"""
+
+    # Model name pattern with spaces
+    bajaj_commons_mapping = {
+        'A92': 'Dominar 160',
+        'A36': 'Dominar 200',
+        'A67': 'Dominar 400',
+        'B65': 'Dominar 250',
+    }
+
+    bajaj_brazil_mapping_by_year_model = {
+        '2026-': {
+            'A92': 'Dominar NS160',
+            'A36': 'Dominar NS200',
+        },
+        '-': {
+            'C41': 'Pulsar N150'
+        }
+    }
+
+    bajaj_brazil_mapping = bajaj_commons_mapping
+    wmi = get_wmi(details)
+    if wmi == '92T':
+        bajaj_brazil_mapping = bajaj_commons_mapping.copy()
+        updates = candidate_by_year_model_mapping(bajaj_brazil_mapping_by_year_model, get_years(details))
+        if updates:
+            bajaj_brazil_mapping.update(updates)
+
+    candidates = {
+        '92T': bajaj_brazil_mapping,
+        '95V': {  # Bajaj assembled by Dafra
+            '2A1': 'Dominar 160',
+            '2B1': 'Dominar 200',
+            '3B1': 'Dominar 400',
+        },
+        'MD2': {
+            **bajaj_commons_mapping,
+            **{
+                # Bajaj India
+                'B54': 'Pulsar N160',
+                'B97': 'Pulsar N250',
+            }
+        }
+    }
+
+    return candidates.get(wmi, {})
+
+
+def get_plant(details):
+    candidates = {
+        'MD2': {  # Bajaj India
+            'C': 'Chakan',
+            'W': 'Waluj',  # Guessing
+            'P': 'Pant Nagar'  # Guessing
+        }
+    }
+
+    return candidates.get(get_wmi(details), {
+        # WMI = 95V or 92T
+        'M': 'Manaus'
+    })
+
+
+class BajajDetails(VinDetails):
+    # for a while, it will be decoded by the first 3 characters of vds
+    model = Detail(('vds', slice(0, 3)), get_model)
+
+    # for a while, it will be a motorcycle regardless of the code source
+    body = Detail(None, constant_info(BODY_MOTORCYCLE))
+
+    plant = Detail(('vis', 1), get_plant)
+
+    serial = Detail(('vis', slice(2, None)))

--- a/vininfo/details/dafra.py
+++ b/vininfo/details/dafra.py
@@ -1,0 +1,20 @@
+from ._base import VinDetails, Detail
+from ..common import constant_info
+from ..dicts.bodies import BODY_MOTORCYCLE
+
+
+class DafraDetails(VinDetails):
+
+    model = Detail(('vds', slice(0, 2)), {
+        'CA': 'SPEED 150',
+        'CB': 'KANSAS 150',
+    })
+
+    # for a while, it will be a motorcycle regardless of the code source
+    body = Detail(None, constant_info(BODY_MOTORCYCLE))
+
+    plant = Detail(('vis', 1), {
+        'M': 'Manaus',
+    })
+
+    serial = Detail(('vis', slice(2, None)))

--- a/vininfo/details/dafra.py
+++ b/vininfo/details/dafra.py
@@ -6,8 +6,8 @@ from ..dicts.bodies import BODY_MOTORCYCLE
 class DafraDetails(VinDetails):
 
     model = Detail(('vds', slice(0, 2)), {
-        'CA': 'SPEED 150',
-        'CB': 'KANSAS 150',
+        'CA': 'Speed 150',
+        'CB': 'Kansas 150',
     })
 
     # for a while, it will be a motorcycle regardless of the code source

--- a/vininfo/dicts/bodies.py
+++ b/vininfo/dicts/bodies.py
@@ -19,3 +19,5 @@ BODY_SW_8 = 'Station Wagon, 8-Door'
 
 BODY_MINIBUS = 'Minibus'
 BODY_VAN = 'Van'
+
+BODY_MOTORCYCLE = 'Motorcycle'

--- a/vininfo/dicts/countries.py
+++ b/vininfo/dicts/countries.py
@@ -142,5 +142,5 @@ COUNTRIES = __unpack_countries_map({
     '9-AE': 'Brazil',
     '9-FG': 'Colombia',
     '9-SV': 'Uruguay',
-    '9-39': 'Brazil',
+    '9-29': 'Brazil',
 })

--- a/vininfo/dicts/wmi.py
+++ b/vininfo/dicts/wmi.py
@@ -1,4 +1,5 @@
-from ..brands import Lada, Nissan, Opel, Renault
+from ..assemblers import Dafra
+from ..brands import Lada, Nissan, Opel, Renault, Bajaj
 
 # NOTE:
 # if you want to extend this mapping with new WMIs, please use
@@ -274,6 +275,7 @@ WMI = {
     '8C3': 'Honda',
     '8GD': 'Peugeot',
     '8GG': 'Chevrolet',
+    '92T': Bajaj(),
     '935': 'Citroën',
     '936': 'Peugeot',
     '93H': 'Honda',
@@ -287,6 +289,7 @@ WMI = {
     '94D': Nissan(),
     '953': 'VW Trucks / MAN',
     '95P': 'CAOA / Hyundai',
+    '95V': Dafra(),
     '988': 'Jeep',
     '98M': 'BMW',
     '98R': 'Chery',
@@ -436,6 +439,7 @@ WMI = {
     'MAT': 'Tata',
     'MBH': Nissan(),
     'MC2': 'Volvo Eicher commercial vehicles limited.',
+    'MD2': Bajaj(),
     'MDH': Nissan(),
     'MHR': 'Honda',
     'ML3': 'Mitsubishi Thailand',


### PR DESCRIPTION
Issue #28 :
-  Introduce an Assembler layer, representing factories that assemble vehicles for one or more brands.
- A Brand may also function as an Assembler, assembling its own models.
- Add Bajaj WMI configuration.
- Add Dafra WMI configuration.
- Add corresponding test cases.
- Refactor the `year` property method to support cases where vehicles are assembled using the next model year.
- Add a `year_code` property method.
- Fix the Nissan test case where the expected years value were incorrect, now returns 2025 based on current year.
- Refine the supported details concept to handle constant-value fields.
- Update the Brazil country code range used for WMI identification.
- Add utility methods to:
    - Emulate constant values for specific vehicle details.
    - Handle model-year transitions where the same model code spans differents model names.