### PR TITLE
Add Windsor Caravans to WMI dictionary

### DIFF
--- a/src/vininfo/dicts/wmi.py
+++ b/src/vininfo/dicts/wmi.py
@@ -246,6 +246,7 @@ WMI = {
     '601': 'Replica/Kit Makes',
     '602': 'Toyota',
     '6AB': 'MAN',
+    '6AL': 'Windsor Caravans',
     '6F': 'Ford',
     '6F4': Nissan('Nissan Motor Company'),
     '6F5': 'Kenworth',


### PR DESCRIPTION
From several other online decoders, `6AL` seems to be the WMI for Windsor Caravans. I could not find any official docs for this besides existing VIM decoders.

E.g. https://www.vindecoderz.com/EN/check-lookup/6ALXXXXXXXXXXXXXX